### PR TITLE
Extend Marks to support select event and a bug fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.js.map
 dist
+node_modules

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ resize = (width: number, height: number) => undefined;
 setSettings = (settings: Object) => undefined
 ```
 
-#### Styles
+#### Settings
 
 ##### Default styles
 
@@ -151,7 +151,7 @@ setSettings = (settings: Object) => undefined
 }
 ```
 
-You can override whatever you want. For example:
+You can override whatever style you want. For example:
 
 ```json
 {
@@ -162,6 +162,29 @@ You can override whatever you want. For example:
 ```
 
 After applying this style, the blocks of the flame chart will be 20 pixels high instead of 16 pixels.
+
+##### Custom Tooltip
+
+You can override or prevent the tooltip render by defining this within the settings objet.
+
+```json
+{  
+  "tooltip": undefined,
+}
+
+```
+
+For example:
+
+```ts
+// prevent tooltip render
+chart.setSettings({ "tooltip": false });
+
+// override tooltip render
+chart.setSettings({ 
+  "tooltip" : (data, renderEngine, mouse) => undefined
+});
+```
 
 #### Data format
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ setSettings = (settings: Object) => undefined
     "graphFillColor": "rgb(0, 0, 0, 0.25)",
     "bottomLineColor": "rgb(0, 0, 0, 0.25)",
     "knobColor": "rgb(131, 131, 131)",
+    "knobStrokeColor": "white",
     "knobSize": 6,
     "height": 60,
     "backgroundColor": "white"
@@ -144,6 +145,7 @@ setSettings = (settings: Object) => undefined
     "font": "10px sans-serif",
     "triangleWidth": 10,
     "triangleHeight": 7,
+    "triangleColor": "black",
     "leftPadding": 10
   }
 }

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -152,12 +152,12 @@ const flameChart = new FlameChart({
     colors
 });
 
-flameChart.on('select', (node) => {
-    setNodeView(node ? JSON.stringify({
+flameChart.on('select', (node, type) => {
+    setNodeView(node ? `${type}\r\n${JSON.stringify({
         ...node,
         children: undefined,
         parent: undefined
-    }, null, '  ') : '');
+    }, null, '  ')}` : '');
 });
 
 window.addEventListener('resize', () => {

--- a/src/engines/basic-render-engine.js
+++ b/src/engines/basic-render-engine.js
@@ -36,7 +36,8 @@ export const defaultRenderSettings = {
             headerStrokeColor: 'rgba(112, 112, 112, 0.5)',
             headerTitleLeftPadding: 16
         }
-    }
+    },
+    tooltip: undefined
 };
 
 export class BasicRenderEngine extends EventEmitter {

--- a/src/engines/render-engine.js
+++ b/src/engines/render-engine.js
@@ -235,16 +235,21 @@ export class RenderEngine extends BasicRenderEngine {
                 this.copy(engine);
             }
         });
-
+        let tooltipRendered = false;
         this.plugins.forEach((plugin) => {
             if (plugin.postRender) {
                 plugin.postRender();
             }
 
             if (plugin.renderTooltip) {
-                plugin.renderTooltip();
+                tooltipRendered = tooltipRendered || !!plugin.renderTooltip();
             }
         });
+
+        if (!tooltipRendered && typeof this.settings.tooltip === "function"){
+            // notify tooltip of nothing to render
+            this.settings.tooltip(null, this, null);
+        }
     }
 
     render() {

--- a/src/index.js
+++ b/src/index.js
@@ -43,6 +43,8 @@ export default class FlameChart extends FlameChartContainer {
 
         if (marks) {
             marksPlugin = new MarksPlugin(marks);
+            marksPlugin.on('select', (node, type) => this.emit('select', node, type));
+
             activePlugins.push(marksPlugin);
         }
 

--- a/src/plugins/flame-chart-plugin.js
+++ b/src/plugins/flame-chart-plugin.js
@@ -13,14 +13,12 @@ const DEFAULT_COLOR = Color.hsl(180, 30, 70);
 export default class FlameChartPlugin extends EventEmitter {
     constructor({
                     data,
-                    colors,
-                    customTooltip
+                    colors
                 }) {
         super();
 
         this.data = data;
         this.userColors = colors;
-        this.customTooltip = customTooltip;
 
         this.parseData(this.data);
         this.reset();
@@ -181,12 +179,13 @@ export default class FlameChartPlugin extends EventEmitter {
 
     renderTooltip() {
         if (this.hoveredRegion) {
-            if (this.customTooltip) {
-                this.customTooltip(
+            if (this.renderEngine.settings.tooltip === false) {
+                return true;
+            } else if (typeof this.renderEngine.settings.tooltip === "function") {
+                this.renderEngine.settings.tooltip(
                     this.hoveredRegion,
                     this.renderEngine,
-                    this.interactionsEngine.getGlobalMouse()
-                );
+                    this.interactionsEngine.getGlobalMouse())
             } else {
                 const { data: { start, duration, children, name } } = this.hoveredRegion;
                 const timeUnits = this.renderEngine.getTimeUnits();

--- a/src/plugins/marks-plugin.js
+++ b/src/plugins/marks-plugin.js
@@ -1,7 +1,9 @@
 import Color from 'color';
+import { EventEmitter } from 'events';
 
-export default class MarksPlugin {
+export default class MarksPlugin extends EventEmitter  {
     constructor(marks) {
+        super();
         this.marks = this.prepareMarks(marks);
 
         this.calcMinMax();
@@ -20,9 +22,25 @@ export default class MarksPlugin {
         this.renderEngine = renderEngine;
         this.interactionsEngine = interactionsEngine;
 
-        this.interactionsEngine.on('hover', (region) => {
-            this.hoveredRegion = region;
-        });
+        this.interactionsEngine.on('hover', this.handleHover.bind(this));
+        this.interactionsEngine.on('select', this.handleSelect.bind(this));
+    }
+
+
+    handleHover(region) {
+        this.hoveredRegion = region;
+    }
+
+    handleSelect(region) {
+        if (region && region.type === 'timestamp') {
+            this.selectedRegion = region;
+            this.emit('select', region.data, 'timestamp');
+            this.renderEngine.render();
+        } else if (this.selectedRegion && !region) {
+            this.selectedRegion = null;
+            this.emit('select', null, 'timestamp');
+            this.renderEngine.render();
+        }
     }
 
     get height() {

--- a/src/plugins/marks-plugin.js
+++ b/src/plugins/marks-plugin.js
@@ -110,17 +110,25 @@ export default class MarksPlugin extends EventEmitter  {
 
     renderTooltip() {
         if (this.hoveredRegion && this.hoveredRegion.type === 'timestamp') {
-            const { data: { fullName, timestamp } } = this.hoveredRegion;
+            if (this.renderEngine.settings.tooltip === false) {
+                return true;
+            } else if (typeof this.renderEngine.settings.tooltip === "function") {
+                this.renderEngine.settings.tooltip(
+                    this.hoveredRegion,
+                    this.renderEngine,
+                    this.interactionsEngine.getGlobalMouse())
+            } else {
+                const { data: { fullName, timestamp } } = this.hoveredRegion;
 
-            const marksAccuracy = this.renderEngine.getAccuracy() + 2;
-            const header = `${fullName}`;
-            const time = `${timestamp.toFixed(marksAccuracy)} ${this.renderEngine.timeUnits}`;
+                const marksAccuracy = this.renderEngine.getAccuracy() + 2;
+                const header = `${fullName}`;
+                const time = `${timestamp.toFixed(marksAccuracy)} ${this.renderEngine.timeUnits}`;
 
-            this.renderEngine.renderTooltipFromData(
-                [{ text: header }, { text: time }],
-                this.interactionsEngine.getGlobalMouse()
-            );
-
+                this.renderEngine.renderTooltipFromData(
+                    [{ text: header }, { text: time }],
+                    this.interactionsEngine.getGlobalMouse()
+                );
+            }
             return true;
         }
     }

--- a/src/plugins/timeframe-selector-plugin.js
+++ b/src/plugins/timeframe-selector-plugin.js
@@ -22,12 +22,13 @@ export const defaultTimeframeSelectorPluginSettings = {
     styles: {
         timeframeSelectorPlugin: {
             font: '9px sans-serif',
-            fontColor: 'black',
+            fontColor: 'black',            
             overlayColor: 'rgba(112, 112, 112, 0.5)',
             graphStrokeColor: 'rgb(0, 0, 0, 0.2)',
             graphFillColor: 'rgb(0, 0, 0, 0.25)',
             bottomLineColor: 'rgb(0, 0, 0, 0.25)',
             knobColor: 'rgb(131, 131, 131)',
+            knobStrokeColor: 'white',
             knobSize: 6,
             height: 60,
             backgroundColor: 'white'
@@ -353,8 +354,8 @@ export default class TimeframeSelectorPlugin {
         this.renderEngine.fillRect(currentLeftKnobPosition, 0, this.styles.knobSize, knobHeight);
         this.renderEngine.fillRect(currentRightKnobPosition, 0, this.styles.knobSize, knobHeight);
 
-        this.renderEngine.renderStroke('white', currentLeftKnobPosition, 0, this.styles.knobSize, knobHeight);
-        this.renderEngine.renderStroke('white', currentRightKnobPosition, 0, this.styles.knobSize, knobHeight);
+        this.renderEngine.renderStroke(this.styles.knobStrokeColor, currentLeftKnobPosition, 0, this.styles.knobSize, knobHeight);
+        this.renderEngine.renderStroke(this.styles.knobStrokeColor, currentRightKnobPosition, 0, this.styles.knobSize, knobHeight);
 
         this.interactionsEngine.addHitRegion('timeframeKnob', 'left', currentLeftKnobPosition, 0, this.styles.knobSize, knobHeight, 'ew-resize');
         this.interactionsEngine.addHitRegion('timeframeKnob', 'right', currentRightKnobPosition, 0, this.styles.knobSize, knobHeight, 'ew-resize');

--- a/src/plugins/toggle-plugin.js
+++ b/src/plugins/toggle-plugin.js
@@ -11,6 +11,7 @@ export const defaultTogglePluginSettings = {
             font: '10px sans-serif',
             triangleWidth: 10,
             triangleHeight: 7,
+            triangleColor: 'black',
             leftPadding: 10
         }
     }
@@ -115,7 +116,7 @@ export default class TogglePlugin {
 
         this.renderEngine.setCtxColor(this.styles.fontColor);
         this.renderEngine.addTextToRenderQueue(this.title, triangleFullWidth, 0, this.renderEngine.width);
-        this.renderEngine.renderTriangle('black', this.styles.leftPadding, 0 + this.styles.height / 2, this.styles.triangleWidth, this.styles.triangleHeight, nextEngine.collapsed ? 'right' : 'bottom');
+        this.renderEngine.renderTriangle(this.styles.triangleColor, this.styles.leftPadding, 0 + this.styles.height / 2, this.styles.triangleWidth, this.styles.triangleHeight, nextEngine.collapsed ? 'right' : 'bottom');
 
         const { width: titleWidth } = this.renderEngine.ctx.measureText(this.title)
         const buttonWidth = titleWidth + triangleFullWidth;

--- a/src/plugins/waterfall-plugin.js
+++ b/src/plugins/waterfall-plugin.js
@@ -130,38 +130,49 @@ export default class WaterfallPlugin extends EventEmitter {
 
     renderTooltip() {
         if (this.hoveredRegion && this.hoveredRegion.type === 'waterfall-node') {
-            const { data: index } = this.hoveredRegion;
-            const { name, intervals, timing, meta } = this.data.find(({ index: i }) => index === i);
-            const timeUnits = this.renderEngine.getTimeUnits();
-            const nodeAccuracy = this.renderEngine.getAccuracy() + 2;
+            if (this.renderEngine.settings.tooltip === false) {
+                return true;
+            } else if (typeof this.renderEngine.settings.tooltip === "function") {
+                const { data: index } = this.hoveredRegion;
+                var data = { ...this.hoveredRegion }
+                data.data = this.data.find(({ index: i }) => index === i)
+                this.renderEngine.settings.tooltip(
+                    data,
+                    this.renderEngine,
+                    this.interactionsEngine.getGlobalMouse())
+            } else {
+                const { data: index } = this.hoveredRegion;
+                const { name, intervals, timing, meta } = this.data.find(({ index: i }) => index === i);
+                const timeUnits = this.renderEngine.getTimeUnits();
+                const nodeAccuracy = this.renderEngine.getAccuracy() + 2;
 
-            const header = { text: `${name}` };
-            const intervalsHeader = { text: 'intervals', color: this.renderEngine.styles.tooltipHeaderFontColor };
-            const intervalsTexts = intervals.map(({ name, start, end }) => ({
-                text: `${name}: ${(end - start).toFixed(nodeAccuracy)} ${timeUnits}`
-            }));
-            const timingHeader = { text: 'timing', color: this.renderEngine.styles.tooltipHeaderFontColor };
-            const timingTexts = Object.entries(timing).map(([name, time]) => ({
-                text: `${name}: ${(time).toFixed(nodeAccuracy)} ${timeUnits}`
-            }));
-            const metaHeader = { text: 'meta', color: this.renderEngine.styles.tooltipHeaderFontColor };
-            const metaTexts = meta ? meta.map(({ name, value, color }) => ({
-                text: `${name}: ${value}`,
-                color
-            })) : []
+                const header = { text: `${name}` };
+                const intervalsHeader = { text: 'intervals', color: this.renderEngine.styles.tooltipHeaderFontColor };
+                const intervalsTexts = intervals.map(({ name, start, end }) => ({
+                    text: `${name}: ${(end - start).toFixed(nodeAccuracy)} ${timeUnits}`
+                }));
+                const timingHeader = { text: 'timing', color: this.renderEngine.styles.tooltipHeaderFontColor };
+                const timingTexts = Object.entries(timing).map(([name, time]) => ({
+                    text: `${name}: ${(time).toFixed(nodeAccuracy)} ${timeUnits}`
+                }));
+                const metaHeader = { text: 'meta', color: this.renderEngine.styles.tooltipHeaderFontColor };
+                const metaTexts = meta ? meta.map(({ name, value, color }) => ({
+                    text: `${name}: ${value}`,
+                    color
+                })) : []
 
-            this.renderEngine.renderTooltipFromData(
-                [
-                    header,
-                    intervalsHeader,
-                    ...intervalsTexts,
-                    timingHeader,
-                    ...timingTexts,
-                    ...(metaTexts.length ? [metaHeader, ...metaTexts] : [])
-                ],
-                this.interactionsEngine.getGlobalMouse()
-            );
-
+                this.renderEngine.renderTooltipFromData(
+                    [
+                        header,
+                        intervalsHeader,
+                        ...intervalsTexts,
+                        timingHeader,
+                        ...timingTexts,
+                        ...(metaTexts.length ? [metaHeader, ...metaTexts] : [])
+                    ],
+                    this.interactionsEngine.getGlobalMouse()
+                );
+            }
             return true;
         }
     }

--- a/src/plugins/waterfall-plugin.js
+++ b/src/plugins/waterfall-plugin.js
@@ -145,10 +145,10 @@ export default class WaterfallPlugin extends EventEmitter {
                 text: `${name}: ${(time).toFixed(nodeAccuracy)} ${timeUnits}`
             }));
             const metaHeader = { text: 'meta', color: this.renderEngine.styles.tooltipHeaderFontColor };
-            const metaTexts = meta.map(({ name, value, color }) => ({
+            const metaTexts = meta ? meta.map(({ name, value, color }) => ({
                 text: `${name}: ${value}`,
                 color
-            }))
+            })) : []
 
             this.renderEngine.renderTooltipFromData(
                 [


### PR DESCRIPTION
- custom tooltip
- hardcoded colors were replaced with style references
- Marks will now support the 'select' event
- a bug on the waterfall plugin when meta was undefined or null is fixed
- ignored the node_modules folder