### PR TITLE
PREFIX-636. Github #15. overlapping spans caused incorrect hit boxing…

### DIFF
--- a/example/src/test-data.js
+++ b/example/src/test-data.js
@@ -114,7 +114,11 @@ export const generateRandomTree = ({
                 }
             }
 
-            item.start = timestamps[index] + rndFloat(currentWindow, 0) * (rndFloat(thinning) / 100);
+            // randomly create an overlapping frame
+            // https://github.com/pyatyispyatil/flame-chart-js/issues/15
+            const overlap = Math.random() >= 0.9 && index > 0;
+
+            item.start = timestamps[overlap ? index -1 : index] + rndFloat(currentWindow, 0) * (rndFloat(thinning) / 100);
             item.end = timestamps[index + 1] - rndFloat(currentWindow, 0) * (rndFloat(thinning) / 100);
             item.duration = item.end - item.start;
             item.name = randomString(14);

--- a/src/engines/basic-render-engine.js
+++ b/src/engines/basic-render-engine.js
@@ -178,42 +178,13 @@ export class BasicRenderEngine extends EventEmitter {
         this.renderQueue.forEach(({type, value}) => {
             switch (type) {
                 case 'rect': 
-                    {
-                        const { color, x, y, w } = value;
-                        this.setCtxColor(color);
-                        this.renderBlock(color, x, y, w);
-                    }
+                    this.resolveRect(value);
                     break;
                 case 'text':
-                    {
-                        const { text, x, y, w, textMaxWidth } = value;
-                        let txt = text;
-                        this.setCtxColor(this.styles.fontColor);
-                        
-                        const { width: textWidth } = this.ctx.measureText(text);
-
-                        if (textWidth > textMaxWidth) {
-                            const avgCharWidth = textWidth / (text.length);
-                            const maxChars = Math.floor((textMaxWidth - this.placeholderWidth) / avgCharWidth);
-                            const halfChars = (maxChars - 1) / 2;
-
-                            if (halfChars > 0) {
-                                txt = text.slice(0, Math.ceil(halfChars)) + '…' + text.slice(value.text.length - Math.floor(halfChars), text.length);
-                            } else {
-                                txt = '';
-                            }
-                        }
-
-                        if (txt) {
-                            this.ctx.fillText(txt, (x < 0 ? 0 : x) + this.blockPaddingLeftRight, y + this.blockHeight - this.blockPaddingTopBottom);
-                        }
-                    }
+                    this.resolveText(value);
                     break;
                 case 'stroke':
-                    {
-                        const { color, x, y, w, h } = value;
-                        this.renderStroke(color, x, y, w, h);
-                    }
+                    this.resolveStroke(value);
                     break;
                 default:
                     console.debug("encountered unhandled render queue case: '%s' value: %o", type, value);
@@ -221,6 +192,42 @@ export class BasicRenderEngine extends EventEmitter {
             }
         });
         this.renderQueue = [];
+    }
+
+    resolveRect(value) {
+        const { color, x, y, w } = value;
+        this.setCtxColor(color);
+        this.renderBlock(color, x, y, w);
+    }
+
+    resolveText(value) {
+        const { text, x, y, w, textMaxWidth } = value;
+        const { width: textWidth } = this.ctx.measureText(text);
+        
+        let txt = text;
+        
+        this.setCtxColor(this.styles.fontColor);
+        
+        if (textWidth > textMaxWidth) {
+            const avgCharWidth = textWidth / (text.length);
+            const maxChars = Math.floor((textMaxWidth - this.placeholderWidth) / avgCharWidth);
+            const halfChars = (maxChars - 1) / 2;
+
+            if (halfChars > 0) {
+                txt = text.slice(0, Math.ceil(halfChars)) + '…' + text.slice(value.text.length - Math.floor(halfChars), text.length);
+            } else {
+                txt = '';
+            }
+        }
+
+        if (txt) {
+            this.ctx.fillText(txt, (x < 0 ? 0 : x) + this.blockPaddingLeftRight, y + this.blockHeight - this.blockPaddingTopBottom);
+        }
+    }
+
+    resolveStroke(value) {
+        const { color, x, y, w, h } = value;
+        this.renderStroke(color, x, y, w, h);
     }
 
     setMinMax(min, max) {

--- a/src/engines/interactions-engine.js
+++ b/src/engines/interactions-engine.js
@@ -175,14 +175,14 @@ export class InteractionsEngine extends EventEmitter {
     }
 
     getHoveredRegion() {
-        const hoveredRegion = this.hitRegions.find(({ x, y, w, h }) => (
+        const hoveredRegion = this.hitRegions.slice().reverse().find(({ x, y, w, h }) => (
             this.mouse.x >= x && this.mouse.x <= x + w && this.mouse.y >= y && this.mouse.y <= y + h
         ));
 
         if (hoveredRegion) {
             return hoveredRegion;
         } else {
-            const hoveredInstance = this.instances.find(({ renderEngine }) => (
+            const hoveredInstance = this.instances.slice().reverse().find(({ renderEngine }) => (
                 renderEngine.position <= this.mouse.y
             ) && (
                 renderEngine.height + renderEngine.position >= this.mouse.y
@@ -193,7 +193,7 @@ export class InteractionsEngine extends EventEmitter {
             if (hoveredInstance) {
                 const offsetTop = hoveredInstance.renderEngine.position;
 
-                return hoveredInstance.hitRegions.find(({ x, y, w, h }) => (
+                return hoveredInstance.hitRegions.slice().reverse().find(({ x, y, w, h }) => (
                     this.mouse.x >= x
                     && this.mouse.x <= x + w
                     && this.mouse.y >= y + offsetTop

--- a/src/engines/interactions-engine.js
+++ b/src/engines/interactions-engine.js
@@ -1,5 +1,15 @@
 import { EventEmitter } from 'events';
 
+function findLast(array, predicate) {
+    let l = array.length;
+    while (l--) {
+        if (predicate(array[l], l, array)) {
+            return array[l]
+        }
+    }
+    return null;
+}
+
 export class InteractionsEngine extends EventEmitter {
     constructor(canvas, renderEngine) {
         super();
@@ -175,14 +185,14 @@ export class InteractionsEngine extends EventEmitter {
     }
 
     getHoveredRegion() {
-        const hoveredRegion = this.hitRegions.slice().reverse().find(({ x, y, w, h }) => (
+        const hoveredRegion = findLast(this.hitRegions, ({ x, y, w, h }) => (
             this.mouse.x >= x && this.mouse.x <= x + w && this.mouse.y >= y && this.mouse.y <= y + h
         ));
 
         if (hoveredRegion) {
             return hoveredRegion;
         } else {
-            const hoveredInstance = this.instances.slice().reverse().find(({ renderEngine }) => (
+            const hoveredInstance = findLast(this.instances, ({ renderEngine }) => (
                 renderEngine.position <= this.mouse.y
             ) && (
                 renderEngine.height + renderEngine.position >= this.mouse.y
@@ -193,7 +203,7 @@ export class InteractionsEngine extends EventEmitter {
             if (hoveredInstance) {
                 const offsetTop = hoveredInstance.renderEngine.position;
 
-                return hoveredInstance.hitRegions.slice().reverse().find(({ x, y, w, h }) => (
+                return findLast(hoveredInstance.hitRegions, ({ x, y, w, h }) => (
                     this.mouse.x >= x
                     && this.mouse.x <= x + w
                     && this.mouse.y >= y + offsetTop

--- a/src/engines/offscreen-render-engine.js
+++ b/src/engines/offscreen-render-engine.js
@@ -109,9 +109,7 @@ export class OffscreenRenderEngine extends BasicRenderEngine {
     }
 
     standardRender() {
-        this.resolveRectRenderQueue();
-        this.resolveTextRenderQueue();
-        this.resolveStrokeRenderQueue();
+        this.resolveRenderQueue();
         this.renderTimeGrid();
     }
 

--- a/src/plugins/waterfall-plugin.js
+++ b/src/plugins/waterfall-plugin.js
@@ -229,7 +229,6 @@ export default class WaterfallPlugin extends UiPlugin {
                 const textStart = this.renderEngine.timeToPosition(textBlock.start);
                 const textEnd = this.renderEngine.timeToPosition(textBlock.end);
 
-                this.renderEngine.addTextToRenderQueue(name, textStart, y, textEnd - textStart);
 
                 const { x, w } = intervals.reduce((acc, { color, start, end, type }, index) => {
                     const { x, w } = this.calcRect(start, end - start, index === intervals.length - 1);
@@ -255,6 +254,7 @@ export default class WaterfallPlugin extends UiPlugin {
                 }
 
                 this.interactionsEngine.addHitRegion('waterfall-node', index, x, y, w, this.renderEngine.blockHeight);
+                this.renderEngine.addTextToRenderQueue(name, textStart, y, textEnd - textStart);
             }
         }, 0);
     }


### PR DESCRIPTION
… and text to also overlap

* Updated render queues to be a single render queue
* Updated hit box searching to find the last hit rather than the first hit under assumption that last hit is the region 'on top'
* Fixed waterfall text render to occur after rectangle render