### PR TITLE
feat(intervals): add basic support for intervals

### DIFF
--- a/example/src/test-data.js
+++ b/example/src/test-data.js
@@ -127,6 +127,17 @@ export const generateRandomTree = ({
             item.name = randomString(14);
             item.type = currentType;
             item.parent = null;
+            const diff = item.end - item.start;
+
+            if (Math.random() > 0.8) {
+                item.intervals = [{
+                    start: item.start + diff / 9,
+                    end: item.start + diff / 6
+                }, {
+                    start: item.start + diff / 3,
+                    end: item.start + diff
+                }];
+            }
 
             counter++;
         });

--- a/src/plugins/flame-chart-plugin.ts
+++ b/src/plugins/flame-chart-plugin.ts
@@ -268,7 +268,7 @@ export default class FlameChartPlugin extends UIPlugin {
         };
 
         const renderCluster = (cluster: ClusterizedFlatTreeNode, x: number, y: number, w: number) => {
-            const { type, nodes, color } = cluster;
+            const { type, nodes, color, intervals, level } = cluster;
             const mouse = this.interactionsEngine.getMouse();
 
             if (mouse.y >= y && mouse.y <= y + blockHeight) {
@@ -277,6 +277,18 @@ export default class FlameChartPlugin extends UIPlugin {
 
             if (w >= 0.25) {
                 this.renderEngine.addRectToRenderQueue(this.getColor(type, color), x, y, w);
+                if (intervals) {
+                    intervals.forEach((interval) => {
+                        const {
+                            w: intervalWidth,
+                            x,
+                            y,
+                        } = this.calcRect(interval.start, interval.end - interval.start, level);
+                        if (w - intervalWidth >= 0.25) {
+                            this.renderEngine.addRectToRenderQueue('white', x, y, intervalWidth, true);
+                        }
+                    });
+                }
             }
 
             if (w >= minTextWidth && nodes.length === 1) {

--- a/src/plugins/utils/tree-clusters.ts
+++ b/src/plugins/utils/tree-clusters.ts
@@ -40,6 +40,10 @@ export const flatTree = (treeList: Data): FlatTree => {
             index: index++,
         };
 
+        if (node.intervals) {
+            newNode.intervals = node.intervals;
+        }
+
         result.push(newNode);
 
         return newNode;
@@ -156,7 +160,7 @@ export const clusterizeFlatTree = (
             const node = nodes[0];
             const duration = calcClusterDuration(nodes);
 
-            return {
+            const result: ClusterizedFlatTreeNode = {
                 start: node.source.start,
                 end: node.source.start + duration,
                 duration,
@@ -165,6 +169,10 @@ export const clusterizeFlatTree = (
                 level: node.level,
                 nodes,
             };
+            if (node.intervals) {
+                result.intervals = node.intervals;
+            }
+            return result;
         });
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,12 @@ export interface Mark {
 
 export type Marks = Array<Mark>;
 
+interface NodeInterval {
+    start: number;
+    end: number;
+}
 export interface Node {
+    intervals?: NodeInterval[];
     name: string; // node name
     start: number; // node start time
     duration: number; // node duration
@@ -61,10 +66,9 @@ interface Rect {
     x: number;
     y: number;
     w: number;
+    isInterval?: boolean;
 }
-export interface RectRenderQueue {
-    [color: string]: Rect[];
-}
+export type RectRenderQueue = Record<string, Rect[]>;
 
 export interface Text {
     text: string;
@@ -88,6 +92,7 @@ export type FlatTreeNode = {
     parent: FlatTreeNode | null;
     level: number;
     index: number;
+    intervals?: NodeInterval[];
 };
 
 export type FlatTree = FlatTreeNode[];
@@ -105,6 +110,7 @@ export interface ClusterizedFlatTreeNode {
     type?: string;
     color?: string;
     level: number;
+    intervals?: NodeInterval[];
     nodes: FlatTreeNode[];
 }
 


### PR DESCRIPTION
 For now it just renders the intervals on the chart.
 It uses pink stripes and alpha transparency rects to preserve the parent fill color.
 In future will add tooltip rendering to intervals and proper self time calculation for parent node
 to show active self time and  interval time