### PR TITLE
fix: expose TimeseriesPlugin

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export { FlameChartPlugin } from './plugins/flame-chart-plugin';
 export { TimeGridPlugin } from './plugins/time-grid-plugin';
 export { MarksPlugin } from './plugins/marks-plugin';
 export { TimeframeSelectorPlugin } from './plugins/timeframe-selector-plugin';
+export { TimeseriesPlugin } from './plugins/timeseries-plugin';
 export { WaterfallPlugin } from './plugins/waterfall-plugin';
 export { TogglePlugin } from './plugins/toggle-plugin';
 


### PR DESCRIPTION
This PR exports TimeseriesPlugin so it could be used with CustomFlamechart while specify plugins list like this:
```
  const plugins = useMemo(() => {
    return [
      new TimeframeSelectorPlugin({ waterfall, settings: {} }),
      new TimeGridPlugin(),
      new TogglePlugin('Timeseries'),
      new TimeseriesPlugin({ name: "Timeseries" , data: timeseries }),
      new TogglePlugin('Waterfall')
    ]
  }, [waterfallData, marksData])
```
