### PR TITLE
fix(deps): correct syntax for peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,8 +61,8 @@
     "events": "^3.2.0"
   },
   "peerDependencies": {
-    "react": "^16.0.0 | ^17.0.0 | ^18.0.0",
-    "react-dom": "^16.0.0 | ^17.0.0 | ^18.0.0",
+    "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
+    "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0",
     "use-resize-observer": "^9.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
While trying to install the latest version of this package I got the following error: 

```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: xxx
npm ERR! Found: react@18.2.0
npm ERR! node_modules/react
npm ERR!   react@"18.2.0" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer react@"^16.0.0 | ^17.0.0 | ^18.0.0" from flame-chart-js@3.2.1
npm ERR! node_modules/flame-chart-js
npm ERR!   flame-chart-js@"^3.2.1" from the root project
```

Upon investigation the issue is that the syntax for peerDependencies is not accepted by `npm` checked via https://semver.npmjs.com/#syntax-examples

## ❌ Invalid 
<img width="742" alt="Screenshot 2023-12-18 at 10 57 39" src="https://github.com/pyatyispyatil/flame-chart-js/assets/20308945/acca158e-9596-4770-8a44-2618a205bca8">

## ✅ Valid 
<img width="743" alt="Screenshot 2023-12-18 at 10 58 06" src="https://github.com/pyatyispyatil/flame-chart-js/assets/20308945/e779984a-9873-4013-aa16-2394be1e210c">
