### PR TITLE
fix(timeframe-selector): re-calculate and re-render

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,8 +63,8 @@
         "use-resize-observer": "^9.1.0"
       },
       "peerDependencies": {
-        "react": "^16.0.0 | ^17.0.0 | ^18.0.0",
-        "react-dom": "^16.0.0 | ^17.0.0 | ^18.0.0",
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0",
         "use-resize-observer": "^9.1.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "flame-chart-js",
-  "version": "3.3.0",
+  "name": "@kong/flame-chart-js",
+  "version": "3.3.0-patch.2",
   "description": "",
   "type": "module",
   "source": "src/index.ts",
@@ -48,14 +48,23 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/pyatyispyatil/flame-chart-js.git"
+    "url": "git+https://github.com/Kong/flame-chart-js.git"
   },
   "author": "Nikolay Ryabov",
+  "contributors": [
+    {
+      "name": "Nikolay Ryabov"
+    },
+    {
+      "name": "Kong Inc.",
+      "url": "https://github.com/Kong"
+    }
+  ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/pyatyispyatil/flame-chart-js/issues"
+    "url": "https://github.com/Kong/flame-chart-js/issues"
   },
-  "homepage": "https://github.com/pyatyispyatil/flame-chart-js#readme",
+  "homepage": "https://github.com/Kong/flame-chart-js#readme",
   "dependencies": {
     "color": "^3.1.3",
     "events": "^3.2.0"

--- a/src/engines/basic-render-engine.ts
+++ b/src/engines/basic-render-engine.ts
@@ -34,6 +34,7 @@ export type RenderOptions = {
         | ((data: any, renderEngine: RenderEngine | OffscreenRenderEngine, mouse: Mouse | null) => boolean | void)
         | boolean;
     timeUnits: string;
+    nonSequential: boolean;
 };
 
 export type RenderStyles = {
@@ -68,13 +69,14 @@ export type RenderSettings = {
 export const defaultRenderSettings: RenderOptions = {
     tooltip: undefined,
     timeUnits: 'ms',
+    nonSequential: false,
 };
 
 export const defaultRenderStyles: RenderStyles = {
     blockHeight: 16,
     blockPaddingLeftRight: 4,
     backgroundColor: 'white',
-    font: '10px sans-serif',
+    font: '10px monospace',
     fontColor: 'black',
     badgeSize: 8,
     tooltipHeaderFontColor: 'black',

--- a/src/engines/time-grid.ts
+++ b/src/engines/time-grid.ts
@@ -25,6 +25,9 @@ export class TimeGrid {
     styles: TimeGridStyles = defaultTimeGridStyles;
     timeUnits = 'ms';
 
+    timeWidth: number;
+    proportion: number;
+
     constructor(settings: TimeGridSettings) {
         this.start = 0;
         this.end = 0;
@@ -48,14 +51,15 @@ export class TimeGrid {
     }
 
     recalc() {
-        const timeWidth = this.renderEngine.max - this.renderEngine.min;
+        this.timeWidth = this.renderEngine.max - this.renderEngine.min;
         const initialLinesCount = this.renderEngine.width / MIN_PIXEL_DELTA;
-        const initialTimeLineDelta = timeWidth / initialLinesCount;
+        const initialTimeLineDelta = this.timeWidth / initialLinesCount;
 
         const realView = this.renderEngine.getRealView();
-        const proportion = realView / (timeWidth || 1);
 
-        this.delta = initialTimeLineDelta / Math.pow(2, Math.floor(Math.log2(1 / proportion)));
+        this.proportion = realView / (this.timeWidth || 1);
+
+        this.delta = initialTimeLineDelta / Math.pow(2, Math.floor(Math.log2(1 / this.proportion)));
         this.start = Math.floor((this.renderEngine.positionX - this.renderEngine.min) / this.delta);
         this.end = Math.ceil(realView / this.delta) + this.start;
 
@@ -112,7 +116,7 @@ export class TimeGrid {
         } else {
             renderEngine.setCtxValue('textAlign', 'center');
             renderEngine.fillText(
-                ((this.end - this.start) * this.delta + this.renderEngine.min).toFixed(this.accuracy) + this.timeUnits,
+                (this.timeWidth * this.proportion).toFixed(this.accuracy) + this.timeUnits,
                 renderEngine.blockPaddingLeftRight + renderEngine.width / 2,
                 renderEngine.charHeight,
             );

--- a/src/engines/time-grid.ts
+++ b/src/engines/time-grid.ts
@@ -101,12 +101,21 @@ export class TimeGrid {
         renderEngine.setCtxValue('fillStyle', renderEngine.styles.fontColor);
         renderEngine.setCtxFont(renderEngine.styles.font);
 
-        this.forEachTime((pixelPosition, timePosition) => {
+        if (!this.renderEngine.options.nonSequential) {
+            this.forEachTime((pixelPosition, timePosition) => {
+                renderEngine.fillText(
+                    timePosition.toFixed(this.accuracy) + this.timeUnits,
+                    pixelPosition + renderEngine.blockPaddingLeftRight,
+                    renderEngine.charHeight,
+                );
+            });
+        } else {
+            renderEngine.setCtxValue('textAlign', 'center');
             renderEngine.fillText(
-                timePosition.toFixed(this.accuracy) + this.timeUnits,
-                pixelPosition + renderEngine.blockPaddingLeftRight,
+                ((this.end - this.start) * this.delta + this.renderEngine.min).toFixed(this.accuracy) + this.timeUnits,
+                renderEngine.blockPaddingLeftRight + renderEngine.width / 2,
                 renderEngine.charHeight,
             );
-        });
+        }
     }
 }

--- a/src/flame-chart.ts
+++ b/src/flame-chart.ts
@@ -1,15 +1,16 @@
 import { FlameChartContainer, FlameChartContainerSettings } from './flame-chart-container';
+import { FlameChartPlugin, FlameChartPluginStyles } from './plugins/flame-chart-plugin';
+import { MarksPlugin } from './plugins/marks-plugin';
 import { TimeGridPlugin, TimeGridPluginStyles } from './plugins/time-grid-plugin';
 import { TimeframeSelectorPlugin, TimeframeSelectorPluginStyles } from './plugins/timeframe-selector-plugin';
-import { WaterfallPlugin, WaterfallPluginStyles } from './plugins/waterfall-plugin';
-import { TogglePlugin, TogglePluginStyles } from './plugins/toggle-plugin';
-import { FlameChartPlugin } from './plugins/flame-chart-plugin';
-import { MarksPlugin } from './plugins/marks-plugin';
-import { Colors, FlameChartNodes, Marks, Timeseries, Waterfall } from './types';
-import { UIPlugin } from './plugins/ui-plugin';
 import { TimeseriesPlugin, TimeseriesPluginStyles } from './plugins/timeseries-plugin';
+import { TogglePlugin, TogglePluginStyles } from './plugins/toggle-plugin';
+import { UIPlugin } from './plugins/ui-plugin';
+import { WaterfallPlugin, WaterfallPluginStyles } from './plugins/waterfall-plugin';
+import { Colors, FlameChartNodes, Marks, Timeseries, Waterfall } from './types';
 
 export type FlameChartStyles = {
+    flameChartPlugin?: Partial<FlameChartPluginStyles>;
     timeGridPlugin?: Partial<TimeGridPluginStyles>;
     timeframeSelectorPlugin?: Partial<TimeframeSelectorPluginStyles>;
     waterfallPlugin?: Partial<WaterfallPluginStyles>;
@@ -100,7 +101,7 @@ export class FlameChart extends FlameChartContainer<FlameChartStyles> {
         }
 
         if (data) {
-            flameChartPlugin = new FlameChartPlugin({ data, colors });
+            flameChartPlugin = new FlameChartPlugin({ data, colors, settings: { styles: styles?.flameChartPlugin } });
             flameChartPlugin.on('select', (data) => this.emit('select', data));
 
             if (waterfall) {

--- a/src/plugins/flame-chart-plugin.ts
+++ b/src/plugins/flame-chart-plugin.ts
@@ -245,10 +245,15 @@ export class FlameChartPlugin extends UIPlugin {
                 const dur = `duration: ${duration.toFixed(nodeAccuracy)} ${timeUnits} ${
                     children?.length ? `(self ${selfTime.toFixed(nodeAccuracy)} ${timeUnits})` : ''
                 }`;
-                const st = `start: ${start.toFixed(nodeAccuracy)}`;
 
                 this.renderEngine.renderTooltipFromData(
-                    [{ text: header }, { text: dur }, { text: st }],
+                    [
+                        { text: header },
+                        { text: dur },
+                        ...(!this.renderEngine.options.nonSequential
+                            ? [{ text: `start: ${start.toFixed(nodeAccuracy)}` }]
+                            : []),
+                    ],
                     this.interactionsEngine.getGlobalMouse(),
                 );
             }

--- a/src/plugins/time-grid-plugin.ts
+++ b/src/plugins/time-grid-plugin.ts
@@ -13,7 +13,7 @@ export type TimeGridPluginSettings = {
 };
 
 export const defaultTimeGridPluginStyles: TimeGridPluginStyles = {
-    font: '10px sans-serif',
+    font: '10px monospace',
     fontColor: 'black',
 };
 

--- a/src/plugins/timeframe-selector-plugin.ts
+++ b/src/plugins/timeframe-selector-plugin.ts
@@ -63,7 +63,7 @@ export type TimeframeSelectorPluginSettings = {
 };
 
 export const defaultTimeframeSelectorPluginStyles: TimeframeSelectorPluginStyles = {
-    font: '9px sans-serif',
+    font: '9px monospace',
     fontColor: 'black',
     overlayColor: 'rgba(112, 112, 112, 0.5)',
     graphStrokeColor: 'rgba(0, 0, 0, 0.10)',
@@ -618,29 +618,31 @@ export class TimeframeSelectorPlugin extends UIPlugin<TimeframeSelectorPluginSty
     }
 
     override renderTooltip(): boolean {
-        if (this.hoveredRegion) {
-            const mouseX = this.interactionsEngine.getMouse().x;
-            const currentTimestamp = mouseX / this.renderEngine.getInitialZoom() + this.renderEngine.min;
+        if (!this.renderEngine.options.nonSequential) {
+            if (this.hoveredRegion) {
+                const mouseX = this.interactionsEngine.getMouse().x;
+                const currentTimestamp = mouseX / this.renderEngine.getInitialZoom() + this.renderEngine.min;
 
-            const time = `${currentTimestamp.toFixed(this.renderEngine.getAccuracy() + 2)} ${
-                this.renderEngine.timeUnits
-            }`;
+                const time = `${currentTimestamp.toFixed(this.renderEngine.getAccuracy() + 2)} ${
+                    this.renderEngine.timeUnits
+                }`;
 
-            const timeseriesFields = this.preparedTimeseries
-                ? renderChartTooltipFields(currentTimestamp, this.preparedTimeseries)
-                : [];
+                const timeseriesFields = this.preparedTimeseries
+                    ? renderChartTooltipFields(currentTimestamp, this.preparedTimeseries)
+                    : [];
 
-            this.renderEngine.renderTooltipFromData(
-                [
-                    {
-                        text: time,
-                    },
-                    ...timeseriesFields,
-                ],
-                this.interactionsEngine.getGlobalMouse(),
-            );
+                this.renderEngine.renderTooltipFromData(
+                    [
+                        {
+                            text: time,
+                        },
+                        ...timeseriesFields,
+                    ],
+                    this.interactionsEngine.getGlobalMouse(),
+                );
 
-            return true;
+                return true;
+            }
         }
 
         return false;

--- a/src/plugins/timeframe-selector-plugin.ts
+++ b/src/plugins/timeframe-selector-plugin.ts
@@ -488,13 +488,12 @@ export class TimeframeSelectorPlugin extends UIPlugin<TimeframeSelectorPluginSty
     }
 
     offscreenRender() {
-        const zoom = this.offscreenRenderEngine.getInitialZoom();
-
-        this.offscreenRenderEngine.setZoom(zoom);
-        this.offscreenRenderEngine.setPositionX(this.offscreenRenderEngine.min);
+        this.offscreenRenderEngine.recalcMinMax();
+        this.offscreenRenderEngine.resetParentView();
         this.offscreenRenderEngine.clear();
 
         this.timeGrid.recalc();
+        this.timeGrid.renderEngine.resetView();
         this.timeGrid.renderLines(0, this.offscreenRenderEngine.height);
         this.timeGrid.renderTimes();
 


### PR DESCRIPTION
While updating the flame chart nodes with `flameChart.setNodes(...)`, it seems that the timeframe selector does not correctly re-calculate or re-render, which causes the chart to be incorrectly zoomed:

![flame-chart-js-reprod-timeframe-selector](https://github.com/pyatyispyatil/flame-chart-js/assets/5277268/ba87be1c-1c20-4100-8631-e2dda18b1889)

Live reproduction is available at: https://stackblitz.com/edit/flame-chart-js-reprod-timeframe-selector?file=main.js

This pull request tries to fix this issue by _(1)_ calling the missing `recalcMinMax`, _(2)_ replacing `setZoom` and `setPosition` with `resetParentView` (this is `setZoom` + `setPosition` + `render`, but it turns out that `render` is necessary here after some trials), and _(3)_ invoking `resetView` on `timeGrid`'s render engine.